### PR TITLE
Signup redirect to root path

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -19,7 +19,7 @@ class WelcomeController < ApplicationController
 
   def welcome
     if current_user.level_three_verified?
-      redirect_to page_path("welcome_level_three_verified")
+      redirect_to root_path
     elsif current_user.level_two_or_three_verified?
       redirect_to page_path("welcome_level_two_verified")
     else

--- a/config/locales/custom/nl/devise.yml
+++ b/config/locales/custom/nl/devise.yml
@@ -37,14 +37,14 @@ nl:
     registrations:
       destroyed: "Jammer dat je gaat! Je account is succesvol verwijderd. Wij hopen je nog een keer terug te zien"
       signed_up: "Je bent inschreven"
-      signed_up_but_inactive: "Je bent geregistreerd. Je kon alleen niet automatisch aangemeld worden omdat jouw account nog niet geactiveerd is. Klik hiervoor op de link die naar jouw e-mailadres is verstuurd. Geen mail ontvangen? Neem dan contact op met noreply@consul.dev\r\n"
-      signed_up_but_locked: "Je bent geregistreerd. Je kon alleen niet automatisch aangemeld worden omdat jouw account geblokkeerd is. Neem hiervoor contact op met noreply@consul.dev"
-      signed_up_but_unconfirmed: "Je ontvangt via de e-mail instructies hoe je jouew account kunt activeren. Geen mail ontvangen? Neem dan contact op met noreply@consul.dev"
+      signed_up_but_inactive: "Je bent geregistreerd. Je kon alleen niet automatisch aangemeld worden omdat jouw account nog niet geactiveerd is. Klik hiervoor op de link die naar jouw e-mailadres is verstuurd. Geen mail ontvangen? Neem dan contact op met stemvan@midden-groningen.nl\r\n"
+      signed_up_but_locked: "Je bent geregistreerd. Je kon alleen niet automatisch aangemeld worden omdat jouw account geblokkeerd is. Neem hiervoor contact op met stemvan@midden-groningen.nl"
+      signed_up_but_unconfirmed: "Je ontvangt via de e-mail instructies hoe je jouw account kunt activeren. Geen mail ontvangen? Neem dan contact op met stemvan@midden-groningen.nl"
       update_needs_confirmation: "U hebt uw e-mailadres succesvol gewijzigd, maar we moeten uw nieuwe mailadres nog verifiëren. Controleer uw e-mail en klik op de link in de mail om uw mailadres te verifiëren"
       updated: "Jouw accountgegevens zijn opgeslagen"
     unlocks:
-      send_instructions: "Je ontvangt via de e-mail instructies hoe je jouw uw account kunt ontgrendelen. Geen mail ontvangen? Neem dan contact op met noreply@consul.dev"
-      send_paranoid_instructions: "Als jouw e-mailadres bij ons bekend is, ontvangt je via de e-mail instructies hoe je jouw account kan ontgrendelen. Kom je niet verder? Neem dan contact op met noreply@consul.dev"
+      send_instructions: "Je ontvangt via de e-mail instructies hoe je jouw uw account kunt ontgrendelen. Geen mail ontvangen? Neem dan contact op met stemvan@midden-groningen.nl"
+      send_paranoid_instructions: "Als jouw e-mailadres bij ons bekend is, ontvangt je via de e-mail instructies hoe je jouw account kan ontgrendelen. Kom je niet verder? Neem dan contact op met stemvan@midden-groningen.nl"
       unlocked: "Je account is succesvol ontgrendeld. Je kunt jezelf weer aanmelden!"
     omniauth_callbacks:
       success: "Successvol aangemeld via %{kind}."

--- a/config/locales/custom/nl/mailers.yml
+++ b/config/locales/custom/nl/mailers.yml
@@ -25,7 +25,7 @@ nl:
       new: "De Coöperatieve Wijkraad heeft naar je idee gekeken. Helaas blijkt dat je idee niet haalbaar is. We leggen ook uit waarom. Je kunt je idee eventueel aanpassen: %{url}."
       new_href: "dat kan hier"
       contact: "Heb je vragen of wil je hulp bij je idee? Mail dan naar %{email}, we denken graag met je mee."
-      email: "noreply@consul.dev"
+      email: "stemvan@midden-groningen.nl"
       sincerely: "Groeten van de Coöperatieve Wijkraad"
     budget_investment_unselected:
       subject: "Helaas heeft je idee het niet gehaald"

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -43,7 +43,7 @@ describe "Welcome screen" do
     login_as(user)
 
     visit welcome_path
-    expect(page).to have_current_path(page_path("welcome_level_three_verified"))
+    expect(page).to have_current_path(root_path)
   end
 
   scenario "a regular user does not see it when coing to /email" do


### PR DESCRIPTION
## Objectives

- Replace `noreply@consul.dev` to  `stemvan@midden-groningen.nl` email on texts.
- Redirect level three verified users to root path.
