### PR TITLE
Delete custom translations from Groningen

### DIFF
--- a/config/locales/custom/nl/budgets.yml
+++ b/config/locales/custom/nl/budgets.yml
@@ -184,7 +184,7 @@ nl:
         change_ballot: "Als je je bedenkt kun je je stemmen in %{check_ballot} verwijderen en opnieuw beginnen."
         different_heading_assigned: "Je hebt al gestemd in een andere groep: %{heading_link}"
       share:
-        message: "Dit is een goed idee voor de Oosterparkwijk! Vanaf 18 november kan je stemmen op dit idee"
+        message: "Ik heb een voorstel voor %{title} gemaakt in de gemeente Midden-Groningen. Bekijk en like mijn idee. Je kunt hierop stemmen vanaf 10 mei."
     show:
       see_all_investments: "Bekijk alle ideeën"
       investments_list: "Ideeën"

--- a/config/locales/custom/nl/general.yml
+++ b/config/locales/custom/nl/general.yml
@@ -74,7 +74,6 @@ nl:
     budget/investment: "idee"
     not_saved: "voorkwam dat %{resource} werd opgeslagen.<br>Controleer alsjeblieft de gemarkeerde velden om ze aan te passen:"
     budget/investment: "idee"
-    accept_terms: "Ik begrijp dat ik een idee indien voor de Oosterparkwijk"
   proposals:
     proposal:
       reason_for_supports_necessary: ""

--- a/config/locales/custom/nl/mailers.yml
+++ b/config/locales/custom/nl/mailers.yml
@@ -15,7 +15,6 @@ nl:
       subject: "Gefeliciteerd, idee '%{code}' gaat door naar de stemronde!"
       title: "Gefeliciteerd, je idee gaat door naar de stemronde!"
       hi: "Beste deelnemer,"
-      share: "De Coöperatieve Wijkraad heeft alle ingediende ideeën bekeken, en gekeken hoeveel het ongeveer gaat kosten. Gefeliciteerd, jouw idee voor de Oosterparkwijk is haalbaar! Je kunt nu beginnen met je campagne. Deel je idee op social media en met je buren.<br>Veel succes!"
       share_button: "Deel je idee"
       sincerely: "Groeten van de Coöperatieve Wijkraad"
       thanks: "Bedankt voor het meedoen."


### PR DESCRIPTION
## Objectives

Delete custom translations specific for Groningen and use the default ones
